### PR TITLE
GCE instance lookup caching

### DIFF
--- a/controls/1.04-iam.rb
+++ b/controls/1.04-iam.rb
@@ -44,21 +44,21 @@ This recommendation is applicable only for User-Managed user created service acc
   google_project_iam_bindings(project: gcp_project_id).where(iam_binding_role: /admin/i ).iam_binding_roles.each do |role|
     describe "[#{gcp_project_id}] Admin roles" do
       subject { google_project_iam_binding(project: gcp_project_id, role: role) }
-      its('members') { should_not include /iam.gserviceaccount.com/ }
+      its('members') { should_not include /@iam.gserviceaccount.com/ }
     end
   end
 
   google_project_iam_bindings(project: gcp_project_id).where(iam_binding_role: 'roles/editor').iam_binding_roles.each do |role|
     describe "[#{gcp_project_id}] Project Editor Role" do
       subject { google_project_iam_binding(project: gcp_project_id, role: role) }
-      its('members') { should_not include /iam.gserviceaccount.com/ }
+      its('members') { should_not include /@iam.gserviceaccount.com/ }
     end
   end
 
   google_project_iam_bindings(project: gcp_project_id).where(iam_binding_role: 'roles/owner').iam_binding_roles.each do |role|
     describe "[#{gcp_project_id}] Project Owner Role" do
       subject { google_project_iam_binding(project: gcp_project_id, role: role) }
-      its('members') { should_not include /iam.gserviceaccount.com/ }
+      its('members') { should_not include /@iam.gserviceaccount.com/ }
     end
   end
 

--- a/controls/4.01-vms.rb
+++ b/controls/4.01-vms.rb
@@ -16,10 +16,13 @@
 title 'Ensure that instances are not configured to use the default service account with full access to all Cloud APIs'
 
 gcp_project_id = attribute('gcp_project_id')
+gce_zones = attribute('gce_zones')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "4.1"
 control_abbrev = "vms"
+
+gce_instances = get_gce_instances(gcp_project_id, gce_zones)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0
@@ -45,12 +48,10 @@ When an instance is configured with Compute Engine default service account with 
   ref "GCP Docs", url: "https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances"
   ref "GCP Docs", url: "https://cloud.google.com/compute/docs/access/service-accounts"
 
-  google_compute_zones(project: gcp_project_id).zone_names.each do |zone|
-    google_compute_instances(project: gcp_project_id, zone: zone).instance_names.each do |instance|
-      describe "[#{gcp_project_id}] #{zone}/#{instance}" do
-        subject { google_compute_instance(project: gcp_project_id, zone: zone, name: instance) }
-        its('service_account_scopes') { should_not include 'https://www.googleapis.com/auth/cloud-platform' }
-      end
+  gce_instances.each do |instance|
+    describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
+      subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
+      its('service_account_scopes') { should_not include 'https://www.googleapis.com/auth/cloud-platform' }
     end
   end
 

--- a/controls/4.05-vms.rb
+++ b/controls/4.05-vms.rb
@@ -16,10 +16,13 @@
 title 'Ensure that IP forwarding is not enabled on Instances'
 
 gcp_project_id = attribute('gcp_project_id')
+gce_zones = attribute('gce_zones')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "4.5"
 control_abbrev = "vms"
+
+gce_instances = get_gce_instances(gcp_project_id, gce_zones)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0
@@ -38,13 +41,11 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   ref "CIS Benchmark", url: "#{cis_url}"
   ref "GCP Docs", url: "https://cloud.google.com/compute/docs/networking#canipforward"
 
-  google_compute_zones(project: gcp_project_id).zone_names.each do |zone|
-    google_compute_instances(project: gcp_project_id, zone: zone).instance_names.each do |instance|
-      next if instance =~ /^gke-/
-      describe "[#{gcp_project_id}] #{zone}/#{instance}" do
-        subject { google_compute_instance(project: gcp_project_id, zone: zone, name: instance) }
-        its('can_ip_forward') { should be false }
-      end
+  gce_instances.each do |instance|
+    next if instance[:name] =~ /^gke-/
+    describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
+      subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
+      its('can_ip_forward') { should be false }
     end
   end
 

--- a/controls/4.06-vms.rb
+++ b/controls/4.06-vms.rb
@@ -16,10 +16,13 @@
 title 'Ensure VM disks for critical VMs are encrypted with CustomerSupplied Encryption Keys (CSEK)'
 
 gcp_project_id = attribute('gcp_project_id')
+gce_zones = attribute('gce_zones')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "4.6"
 control_abbrev = "vms"
+
+gce_instances = get_gce_instances(gcp_project_id, gce_zones)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0
@@ -46,13 +49,11 @@ At least business critical VMs should have VM disks encrypted with CSEK."
   ref "GCP Docs", url: "https://cloud.google.com/compute/docs/reference/rest/v1/disks/get"
   ref "GCP Docs", url: "https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#key_file"
 
-  google_compute_zones(project: gcp_project_id).zone_names.each do |zone|
-    google_compute_instances(project: gcp_project_id, zone: zone).instance_names.each do |instance|
-      next if instance =~ /^gke-/
-      describe "[#{gcp_project_id}] #{zone}/#{instance}" do
-        subject { google_compute_instance(project: gcp_project_id, zone: zone, name: instance) }
-        it { should have_disks_encrypted_with_csek }
-      end
+  gce_instances.each do |instance|
+    next if instance[:name] =~ /^gke-/
+    describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
+      subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
+      it { should have_disks_encrypted_with_csek }
     end
   end
 

--- a/controls/7.01-gke.rb
+++ b/controls/7.01-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Stackdriver Logging is set to Enabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.1"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.02-gke.rb
+++ b/controls/7.02-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Stackdriver Monitoring is set to Enabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.2"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.03-gke.rb
+++ b/controls/7.03-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Legacy Authorization is set to Disabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.3"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.04-gke.rb
+++ b/controls/7.04-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Master authorized networks is set to Enabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.4"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0
@@ -48,8 +49,8 @@ Restricting access to an authorized network can provide additional security bene
   gke_clusters.each do |gke_cluster|
     describe "[#{gcp_project_id}] Cluster #{gke_cluster[:location]}/#{gke_cluster[:cluster_name]}" do
       subject { google_container_regional_cluster(project: gcp_project_id, location: gke_cluster[:location], name: gke_cluster[:cluster_name]) }
-      # TODO Inspec-GCP support
-      its('master_authorized_networks_config.cidr_blocks') { should exist }
+      its('master_authorized_networks_config.cidr_blocks') { should_not be_empty }
+      its('master_authorized_networks_config.cidr_blocks.to_s') { should_not match /0.0.0.0\/0/ }
     end
   end
 

--- a/controls/7.05-gke.rb
+++ b/controls/7.05-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes Clusters are configured with Labels'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.5"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.06-gke.rb
+++ b/controls/7.06-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes web UI / Dashboard is disabled'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.6"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.07-gke.rb
+++ b/controls/7.07-gke.rb
@@ -16,12 +16,13 @@
 title "Ensure 'Automatic node repair' is enabled for Kubernetes Clusters"
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.7"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.08-gke.rb
+++ b/controls/7.08-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Automatic node upgrades is enabled on Kubernetes Engine Clusters nodes'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.8"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.09-gke.rb
+++ b/controls/7.09-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.9"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.10-gke.rb
+++ b/controls/7.10-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Basic Authentication is disabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.10"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.11-gke.rb
+++ b/controls/7.11-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Network policy is enabled on Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.11"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.12-gke.rb
+++ b/controls/7.12-gke.rb
@@ -44,7 +44,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   gke_clusters.each do |gke_cluster|
     describe "[#{gcp_project_id}] Cluster #{gke_cluster[:location]}/#{gke_cluster[:cluster_name]}" do
       subject { google_container_regional_cluster(project: gcp_project_id, location: gke_cluster[:location], name: gke_cluster[:cluster_name]) }
-      its('master_auth.client_certificate') { should cmp nil }
+      its('master_auth.client_certificate') { should_not cmp nil }
     end
   end
 end

--- a/controls/7.12-gke.rb
+++ b/controls/7.12-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes Cluster is created with Client Certificate enabled'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.12"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0
@@ -43,7 +44,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   gke_clusters.each do |gke_cluster|
     describe "[#{gcp_project_id}] Cluster #{gke_cluster[:location]}/#{gke_cluster[:cluster_name]}" do
       subject { google_container_regional_cluster(project: gcp_project_id, location: gke_cluster[:location], name: gke_cluster[:cluster_name]) }
-      its('master_auth.client_certificate') { should_not cmp nil }
+      its('master_auth.client_certificate') { should cmp nil }
     end
   end
 end

--- a/controls/7.13-gke.rb
+++ b/controls/7.13-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes Cluster is created with Alias IP ranges enabled'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.13"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.14-gke.rb
+++ b/controls/7.14-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.14"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.15-gke.rb
+++ b/controls/7.15-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes Cluster is created with Private cluster enabled'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.15"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.16-gke.rb
+++ b/controls/7.16-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Private Google Access is set on Kubernetes Engine Cluster Subnets'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.16"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.17-gke.rb
+++ b/controls/7.17-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure default Service account is not used for Project access in Kubernetes Clusters'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.17"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/controls/7.18-gke.rb
+++ b/controls/7.18-gke.rb
@@ -16,12 +16,13 @@
 title 'Ensure Kubernetes Clusters created with limited service account Access scopes for Project access'
 
 gcp_project_id = attribute('gcp_project_id')
+gcp_gke_locations = attribute('gcp_gke_locations')
 cis_version = attribute('cis_version')
 cis_url = attribute('cis_url')
 control_id = "7.18"
 control_abbrev = "gke"
 
-gke_clusters = get_gke_clusters(gcp_project_id)
+gke_clusters = get_gke_clusters(gcp_project_id, gcp_gke_locations)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 1.0

--- a/inspec.yml
+++ b/inspec.yml
@@ -46,6 +46,11 @@ attributes:
   # example = "-logging"
   value: "replace-with-bucket-name-or-partial-match"
   type: string
+- name: gcp_gke_locations
+  description: 'The list of regions and/or zone names where GKE clusters are running. An empty array searches all locations'
+  type: array
+  value:
+    - ""
 depends:
 - name: inspec-gcp
   git: https://github.com/inspec/inspec-gcp.git

--- a/inspec.yml
+++ b/inspec.yml
@@ -51,6 +51,11 @@ attributes:
   type: array
   value:
     - ""
+- name: gce_zones
+  description: 'The list of zone names where GCE instances are running. An empty array searches all locations'
+  type: array
+  value:
+    - ""
 depends:
 - name: inspec-gcp
   git: https://github.com/inspec/inspec-gcp.git

--- a/libraries/gcp_helpers.rb
+++ b/libraries/gcp_helpers.rb
@@ -18,23 +18,32 @@ module GcpHelpers
     @gke_clusters_cached = false
     @gke_locations = []
 
-    def get_gke_clusters(gcp_project_id)
+    def get_gke_clusters(gcp_project_id, gcp_gke_locations)
       unless @gke_clusters_cached == true
+        # Reset the list of cached clusters
         @cached_gke_clusters = []
         begin
-          @gke_locations = google_compute_zones(project: gcp_project_id).zone_names
-          @gke_locations += google_compute_regions(project: gcp_project_id).region_names
+          # If we weren't passed a specific list/array of zones/region names from inputs, search everywhere 
+          if gcp_gke_locations.empty?
+            @gke_locations = google_compute_zones(project: gcp_project_id).zone_names
+            @gke_locations += google_compute_regions(project: gcp_project_id).region_names
+          else
+            @gke_locations = gcp_gke_locations
+          end
 
+          # Loop/fetch/cache the names and locations of GKE clusters
           @gke_locations.each do |gke_location|
             google_container_regional_clusters(project: gcp_project_id, location: gke_location).names.each do |gke_cluster|
               @cached_gke_clusters.push({:cluster_name => gke_cluster, :location => gke_location})
             end
           end
+          # Mark the cache as full
           @gke_clusters_cached = true
         rescue NoMethodError
           # During inspec check, the mock transport connection doesn't set up a gcp_compute_client method
         end
       end
+      # Return the list of clusters
       return @cached_gke_clusters
     end
 

--- a/libraries/gcp_helpers.rb
+++ b/libraries/gcp_helpers.rb
@@ -47,6 +47,34 @@ module GcpHelpers
       return @cached_gke_clusters
     end
 
+    def get_gce_instances(gcp_project_id, gce_zones)
+      unless @gce_instances_cached == true
+        # Set the list of cached intances
+        @cached_gce_instances = []
+        begin
+          # If we weren't passed a specific list/array of zone names from inputs, search everywhere 
+          if gce_zones.empty?
+            @gce_zones = google_compute_zones(project: gcp_project_id).zone_names
+          else
+            @gce_zones = gce_zones
+          end
+
+          # Loop/fetch/cache the names and locations of GKE clusters
+          @gce_zones.each do |gce_zone|
+            google_compute_instances(project: gcp_project_id, zone: gce_zone).instance_names.each do |instance|
+              @cached_gce_instances.push({:name => instance, :zone => gce_zone})
+            end
+          end
+          # Mark the cache as full
+          @gce_instances_cached = true
+        rescue NoMethodError
+          # During inspec check, the mock transport connection doesn't set up a gcp_compute_client method
+        end
+      end
+      # Return the list of clusters
+      return @cached_gce_instances
+    end
+
 end
 
 ::Inspec::DSL.include(GcpHelpers)


### PR DESCRIPTION
Similar to the GKE cluster lookup caching helper, do the same for GCE instances to only have to use the plural resource once for the entire profile run.