### PR TITLE
Kschieban/inspec gcpv1.4.0

### DIFF
--- a/controls/1.04-iam.rb
+++ b/controls/1.04-iam.rb
@@ -51,11 +51,9 @@ Even after owners precaution, keys can be easily leaked by common development ma
   google_service_accounts(project: gcp_project_id).service_account_emails.each do |sa_email|
     if google_service_account_keys(project: gcp_project_id, service_account: sa_email).key_names.count > 1
       impact 1.0
-      google_service_account_keys(project: gcp_project_id, service_account: sa_email).key_names.each do |key_name|
-        describe "[#{gcp_project_id}] Service Account: #{sa_email}" do
-          subject { google_service_account_key(name: key_name) }
-          its('key_type') { should_not eq 'USER_MANAGED' }
-        end
+      describe "[#{gcp_project_id}] Service Account: #{sa_email}" do
+        subject { google_service_account_keys(project: gcp_project_id, service_account: sa_email) }
+        its('key_types') { should_not include 'USER_MANAGED' }
       end
     else
       impact 0

--- a/inspec.yml
+++ b/inspec.yml
@@ -24,7 +24,7 @@ supports:
   - platform: gcp
 depends:
   - name: inspec-gcp
-    url: https://github.com/inspec/inspec-gcp/archive/v1.4.0.tar.gz
+    url: https://github.com/inspec/inspec-gcp/archive/v1.5.0.tar.gz
   - name: inspec-gcp-helpers
     url: https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/archive/v1.0.0.tar.gz
 inputs:


### PR DESCRIPTION
Using inspec-gcp v1.5.0 now, service account keys are being pulled correctly