### PR TITLE
Fixing the if statement which checks for Cloud KMS Admins

### DIFF
--- a/controls/1.11-iam.rb
+++ b/controls/1.11-iam.rb
@@ -44,7 +44,7 @@ Any user(s) should not have Cloud KMS Admin and any of the Cloud KMS CryptoKey E
 
   kms_admins = google_project_iam_binding(project: gcp_project_id, role: 'roles/cloudkms.admin')
 
-  if kms_admins.members.count.zero?
+  if kms_admins.members.nil? || kms_admins.members.count.zero?
     impact 'none'
     describe "[#{gcp_project_id}] does not have users with roles/CloudKMSAdmin. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have users with roles/CloudKMSAdmin"


### PR DESCRIPTION
Fix for the following error:
```
  ×  cis-gcp-1.11-iam: [IAM] Ensure that Separation of duties is enforced while assigning KMS related roles to users
     ×  Control Source Code Error inspec-gcp-cis-benchmark-1.1.0/controls/1.11-iam.rb:23
     undefined method `count' for nil:NilClass
```