### PR TITLE
Fix mismatching control IDs

### DIFF
--- a/controls/4.05-vms.rb
+++ b/controls/4.05-vms.rb
@@ -18,7 +18,7 @@ gcp_project_id = input('gcp_project_id')
 gce_zones = input('gce_zones')
 cis_version = input('cis_version')
 cis_url = input('cis_url')
-control_id = '4.4'
+control_id = '4.5'
 control_abbrev = 'vms'
 
 gce_instances = GCECache(project: gcp_project_id, gce_zones: gce_zones).gce_instances_cache

--- a/controls/4.07-vms.rb
+++ b/controls/4.07-vms.rb
@@ -18,7 +18,7 @@ gcp_project_id = input('gcp_project_id')
 gce_zones = input('gce_zones')
 cis_version = input('cis_version')
 cis_url = input('cis_url')
-control_id = '4.6'
+control_id = '4.7'
 control_abbrev = 'vms'
 
 gce_instances = GCECache(project: gcp_project_id, gce_zones: gce_zones).gce_instances_cache

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-7"
+version: "1.1.0-8"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
Just noticed the mismatch which can be problematic when generating
InSpec reports. It can result in duplication of fields and/or inconsistent
results in reports.

Example where references from two controls are merged into one resulting
in a structure which is difficult to parse:
```
          ...
          "refs": [
            {
              "url": "https://www.cisecurity.org/benchmark/google_cloud_computing_platform/",
              "ref": "CIS Benchmark"
            },
            {
              "url": "https://cloud.google.com/compute/docs/networking#canipforward",
              "ref": "GCP Docs"
            },
            {
              "ref": [
                {
                  "url": "https://www.cisecurity.org/benchmark/google_cloud_computing_platform/",
                  "ref": "CIS Benchmark"
                },
                {
                  "url": "https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#encrypt_a_new_persistent_disk_with_your_own_keys",
                  "ref": "GCP Docs"
                },
                {
                  "url": "https://cloud.google.com/compute/docs/reference/rest/v1/disks/get",
                  "ref": "GCP Docs"
                },
                {
                  "url": "https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#key_file",
                  "ref": "GCP Docs"
                }
              ]
            }
          ]
          ...
```

Luckily the fix is simple :)