### PR TITLE
Verify whether automatic key rotation is enabled only for symmetric keys

### DIFF
--- a/controls/1.10-iam.rb
+++ b/controls/1.10-iam.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-title 'Ensure Symmetric Encryption keys are rotated within a period of 90 days'
+title 'Ensure Encryption keys are rotated within a period of 90 days'
 
 gcp_project_id = input('gcp_project_id')
 cis_version = input('cis_version')
@@ -24,9 +24,9 @@ kms_rotation_period_seconds = input('kms_rotation_period_seconds')
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 'medium'
 
-  title "[#{control_abbrev.upcase}] Ensure Symmetric Encryption keys are rotated within a period of 90 days"
+  title "[#{control_abbrev.upcase}] Ensure Encryption keys are rotated within a period of 90 days"
 
-  desc "Google Cloud Key Management Service (KMS) stores cryptographic keys in a hierarchical structure designed for useful and elegant access control management. Access to resources.
+  desc "Google Cloud Key Management Service (KMS) stores cryptographic keys in a hierarchical structure designed for useful and elegant access control management.
 
 Automatic cryptographic key rotation is only available for symmetric keys. Cloud KMS does not support automatic rotation of asymmetric keys so such keys are out of scope for this control. More information can be found in the GCP documentation references of this control.
 

--- a/controls/1.10-iam.rb
+++ b/controls/1.10-iam.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-title 'Ensure Encryption keys are rotated within a period of 90 days'
+title 'Ensure Symmetric Encryption keys are rotated within a period of 90 days'
 
 gcp_project_id = input('gcp_project_id')
 cis_version = input('cis_version')
@@ -24,9 +24,11 @@ kms_rotation_period_seconds = input('kms_rotation_period_seconds')
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 'medium'
 
-  title "[#{control_abbrev.upcase}] Ensure Encryption keys are rotated within a period of 90 days"
+  title "[#{control_abbrev.upcase}] Ensure Symmetric Encryption keys are rotated within a period of 90 days"
 
-  desc "Google Cloud Key Management Service stores cryptographic keys in a hierarchical structure designed for useful and elegant access control management. Access to resources.
+  desc "Google Cloud Key Management Service (KMS) stores cryptographic keys in a hierarchical structure designed for useful and elegant access control management. Access to resources.
+
+Automatic cryptographic key rotation is only available for symmetric keys. Cloud KMS does not support automatic rotation of asymmetric keys so such keys are out of scope for this control. More information can be found in the GCP documentation references of this control.
 
 The format for the rotation schedule depends on the client library that is used. For the gcloud command-line tool, the next rotation time must be in ISO or RFC3339 format, and the rotation period must be in the form INTEGER[UNIT], where units can be one of seconds (s), minutes (m), hours (h) or days (d)."
 
@@ -42,6 +44,7 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation'
+  ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#asymmetric'
 
   # Get all "normal" regions and add "global"
   locations = google_compute_regions(project: gcp_project_id).region_names
@@ -66,7 +69,7 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
         else
           kms_cache.kms_crypto_keys[location][keyring].each do |keyname|
             key = google_kms_crypto_key(project: gcp_project_id, location: location, key_ring_name: keyring, name: keyname)
-            next unless key.primary_state == 'ENABLED'
+            next unless key.purpose == 'ENCRYPT_DECRYPT' && key.primary_state == 'ENABLED'
             describe "[#{gcp_project_id}] #{key.crypto_key_name}" do
               subject { key }
               its('rotation_period') { should_not eq nil }

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-9"
+version: "1.1.0-10"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
/gcbrun

Since the GCP Key Management Service does not support automatic rotation
of asymmetric keys (see: [Considerations for asymmetric keys](https://cloud.google.com/kms/docs/key-rotation#asymmetric)) and the fact that
KMS API calls for asymmetric keys don't return `enabled` and `disabled` state,
checks running against such keys are failing at the moment. That's why
we should only test KMS cryptographic keys which are symmetric.

Fixes error:
```
     ×  Control Source Code Error inspec-gcp-cis-benchmark-1.1.0-9/controls/1.10-iam.rb:24
          undefined method `[]' for nil:NilClass
```