### PR TITLE
Fixes around Editor and Owner permissions checks

### DIFF
--- a/controls/1.05-iam.rb
+++ b/controls/1.05-iam.rb
@@ -49,14 +49,14 @@ This recommendation is applicable only for User-Managed user created service acc
     end
   end
 
-  iam_bindings_cache.iam_bindings.keys.grep(/roles\/editor/i).each do |role|
+  iam_bindings_cache.iam_bindings.keys.grep(%r{roles/editor}).each do |role|
     describe "[#{gcp_project_id}] Project Editor Role" do
       subject { iam_bindings_cache.iam_bindings[role] }
       its('members') { should_not include(/@iam.gserviceaccount.com/) }
     end
   end
 
-  iam_bindings_cache.iam_bindings.keys.grep(/roles\/owner/i).each do |role|
+  iam_bindings_cache.iam_bindings.keys.grep(%r{roles/owner}).each do |role|
     describe "[#{gcp_project_id}] Project Owner Role" do
       subject { iam_bindings_cache.iam_bindings[role] }
       its('members') { should_not include(/@iam.gserviceaccount.com/) }

--- a/controls/1.05-iam.rb
+++ b/controls/1.05-iam.rb
@@ -49,13 +49,17 @@ This recommendation is applicable only for User-Managed user created service acc
     end
   end
 
-  describe "[#{gcp_project_id}] Project Editor Role" do
-    subject { iam_bindings_cache.iam_bindings['roles/editor'] }
-    its('members') { should_not include(/@iam.gserviceaccount.com/) }
+  iam_bindings_cache.iam_bindings.keys.grep(/roles\/editor/i).each do |role|
+    describe "[#{gcp_project_id}] Project Editor Role" do
+      subject { iam_bindings_cache.iam_bindings[role] }
+      its('members') { should_not include(/@iam.gserviceaccount.com/) }
+    end
   end
 
-  describe "[#{gcp_project_id}] Project Owner Role" do
-    subject { iam_bindings_cache.iam_bindings['roles/owner'] }
-    its('members') { should_not include(/@iam.gserviceaccount.com/) }
+  iam_bindings_cache.iam_bindings.keys.grep(/roles\/owner/i).each do |role|
+    describe "[#{gcp_project_id}] Project Owner Role" do
+      subject { iam_bindings_cache.iam_bindings[role] }
+      its('members') { should_not include(/@iam.gserviceaccount.com/) }
+    end
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-10"
+version: "1.1.0-11"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
We are staying away from primitive roles as much as possible and since
recently we are no longer using the Owner role in our projects. That
resulted in InSpec errors because there were no longer any IAM
bindings with that role. With the following fix, InSpec will look for
any bindings related to Editor/Owner and, in case of any present, will
examine those.