### PR TITLE
Fix exclusion logics for GKE

### DIFF
--- a/controls/4.01-vms.rb
+++ b/controls/4.01-vms.rb
@@ -43,6 +43,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
 
   project_number = google_project(project: gcp_project_id).project_number
   gce_instances.each do |instance|
+    next if instance[:name] =~ /^gke-/
     google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]).service_accounts.each do |serviceaccount|
       describe "VM #{instance[:name]} should not include the default compute engine service account" do
         subject { serviceaccount.email }

--- a/controls/4.02-vms.rb
+++ b/controls/4.02-vms.rb
@@ -48,6 +48,7 @@ When an instance is configured with Compute Engine default service account with 
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/access/service-accounts'
 
   gce_instances.each do |instance|
+    next if instance[:name] =~ /^gke-/
     describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
       subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
       its('service_account_scopes') { should_not include 'https://www.googleapis.com/auth/cloud-platform' }

--- a/controls/4.05-vms.rb
+++ b/controls/4.05-vms.rb
@@ -47,7 +47,6 @@ Therefore interactive serial console support should be disabled."
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/interacting-with-serial-console'
 
   gce_instances.each do |instance|
-    next if instance[:name] =~ /^gke-/
     describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
       subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
       it { should have_serial_port_disabled }

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-13"
+version: "1.1.0-14"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
I just checked the section 4 of the latest documentation (ver1.1.0 03-11-2020) and it looks like the exclusion logics for GKE are wrong.

- Control 4.1 excludes instances created by GKE, see page 122.
- Control 4.2 excludes instances created by GKE, see page 125.
- Control 4.5 includes instances created by GKE, because of an exception isn't mentioned, see page 134 onwards.

Please review this pr. Thank you for your time.