### PR TITLE
Skip non default service account with full access to all Cloud APIs

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-16"
+version: "1.1.0-17"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
Skip **non** default service account with full access to all Cloud APIs for Control 4.2; `Ensure that instances are not configured to use the default service account with full access to all Cloud APIs (Scored)`.

FYI, I used the following code as a guide.
https://github.com/GoogleCloudPlatform/inspec-gcp-cis-benchmark/blob/40781b7ecb15ec751ee8051c1a218ac13cef805a/controls/4.01-vms.rb#L44-L53

Please review this pr. Thank you for your time again 😄