### PR TITLE
List required APIs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ Test Summary: 166 successful, 7 failures, 7 skipped
 
 ### Required APIs
 
-The following GCP APIs should be enabled
-in **both** the *source* project of the Service Account that runs the scan
-and the *target* project to be scanned:
+Consider these GCP projects, which may all be the same or different:
+* the project of the Service Account that's used to authenticate the scan
+* the project from which the benchmark is called
+* the project to be scanned
 
+The following GCP APIs should be enabled in **all** of these projects:
 * cloudkms.googleapis.com
 * cloudresourcemanager.googleapis.com
 * compute.googleapis.com

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Profile Summary: 48 successful controls, 5 control failures, 7 controls skipped
 Test Summary: 166 successful, 7 failures, 7 skipped
 ```
 
+### Required APIs
+
+The following GCP APIs should be enabled
+in **both** the *source* project of the Service Account that runs the scan
+and the *target* project to be scanned:
+
+* cloudkms.googleapis.com
+* cloudresourcemanager.googleapis.com
+* compute.googleapis.com
+* dns.googleapis.com
+* iam.googleapis.com
+* logging.googleapis.com
+* monitoring.googleapis.com
+* sqladmin.googleapis.com
+* storage-api.googleapis.com
+  
 ### Required Permissions
 The following permissions are required to run the CIS benchmark profile:
 


### PR DESCRIPTION
This PR adds documentation to resolve access control issues described in https://github.com/GoogleCloudPlatform/inspec-gcp-cis-benchmark/issues/54.

Namely, besides the required permissions, a number of Google APIs must be enabled in both the "source" project of the Service Account that runs the benchmark, and the "target" project to be scanned (as these projects may be the same or different).