### PR TITLE
Fix GCP permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ Test Summary: 166 successful, 7 failures, 7 skipped
 
 ### Required APIs
 
-The following GCP APIs should be enabled
-in **both** the *source* project of the Service Account that runs the scan
-and the *target* project to be scanned:
+Consider these GCP projects, which may all be the same or different:
+* the project of the Service Account that's used to authenticate the scan
+* the project from which the benchmark is called
+* the project to be scanned
 
+The following GCP APIs should be enabled in **all** of these projects:
 * cloudkms.googleapis.com
 * cloudresourcemanager.googleapis.com
 * compute.googleapis.com

--- a/README.md
+++ b/README.md
@@ -99,5 +99,6 @@ On project level:
 * monitoring.alertPolicies.list
 * resourcemanager.projects.get
 * resourcemanager.projects.getIamPolicy
+* storage.buckets.get
 * storage.buckets.getIamPolicy
 * storage.buckets.list

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Profile Summary: 48 successful controls, 5 control failures, 7 controls skipped
 Test Summary: 166 successful, 7 failures, 7 skipped
 ```
 
+### Required APIs
+
+The following GCP APIs should be enabled
+in **both** the *source* project of the Service Account that runs the scan
+and the *target* project to be scanned:
+
+* cloudkms.googleapis.com
+* cloudresourcemanager.googleapis.com
+* compute.googleapis.com
+* dns.googleapis.com
+* iam.googleapis.com
+* logging.googleapis.com
+* monitoring.googleapis.com
+* sqladmin.googleapis.com
+* storage-api.googleapis.com
+  
 ### Required Permissions
 The following permissions are required to run the CIS benchmark profile:
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,10 @@ Test Summary: 166 successful, 7 failures, 7 skipped
 
 ### Required APIs
 
-Consider these GCP projects, which may all be the same or different:
-* the project of the Service Account that's used to authenticate the scan
-* the project from which the benchmark is called
-* the project to be scanned
+The following GCP APIs should be enabled
+in **both** the *source* project of the Service Account that runs the scan
+and the *target* project to be scanned:
 
-The following GCP APIs should be enabled in **all** of these projects:
 * cloudkms.googleapis.com
 * cloudresourcemanager.googleapis.com
 * compute.googleapis.com

--- a/README.md
+++ b/README.md
@@ -58,22 +58,6 @@ Profile Summary: 48 successful controls, 5 control failures, 7 controls skipped
 Test Summary: 166 successful, 7 failures, 7 skipped
 ```
 
-### Required APIs
-
-The following GCP APIs should be enabled
-in **both** the *source* project of the Service Account that runs the scan
-and the *target* project to be scanned:
-
-* cloudkms.googleapis.com
-* cloudresourcemanager.googleapis.com
-* compute.googleapis.com
-* dns.googleapis.com
-* iam.googleapis.com
-* logging.googleapis.com
-* monitoring.googleapis.com
-* sqladmin.googleapis.com
-* storage-api.googleapis.com
-
 ### Required Permissions
 The following permissions are required to run the CIS benchmark profile:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ gem install inspec-bin --no-document --quiet
 $ gcloud auth list
 
 # acquire credentials to use with Application Default Credentials
-$ gcloud auth application-default login 
+$ gcloud auth application-default login
 
 ```
 
@@ -75,7 +75,7 @@ The following GCP APIs should be enabled in **all** of these projects:
 * monitoring.googleapis.com
 * sqladmin.googleapis.com
 * storage-api.googleapis.com
-  
+
 ### Required Permissions
 The following permissions are required to run the CIS benchmark profile:
 
@@ -92,16 +92,22 @@ On project level:
 * cloudkms.keyRings.list
 * cloudsql.instances.get
 * cloudsql.instances.list
+* compute.firewalls.get
 * compute.firewalls.list
 * compute.instances.get
 * compute.instances.list
+* compute.networks.get
 * compute.networks.list
+* compute.projects.get
 * compute.regions.list
 * compute.sslPolicies.get
 * compute.sslPolicies.list
 * compute.subnetworks.get
 * compute.subnetworks.list
+* compute.targetHttpsProxies.get
 * compute.targetHttpsProxies.list
+* compute.zones.list
+* dns.managedZones.get
 * dns.managedZones.list
 * iam.serviceAccountKeys.list
 * iam.serviceAccounts.list
@@ -111,4 +117,5 @@ On project level:
 * monitoring.alertPolicies.list
 * resourcemanager.projects.get
 * resourcemanager.projects.getIamPolicy
+* storage.buckets.getIamPolicy
 * storage.buckets.list


### PR DESCRIPTION
This PR adds missing GCP permissions that were discovered in our benchmark runs through Stackdriver Audit log activity.

Please don't merge yet, as we will verify if these are sufficient still.