### PR TITLE
Fix looping over the Cloud SQL database flags

### DIFF
--- a/controls/6.01-db.rb
+++ b/controls/6.01-db.rb
@@ -82,6 +82,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'local_infile'
             describe flag do
               its('name') { should cmp 'local_infile' }
               its('value') { should cmp 'off' }

--- a/controls/6.02-db.rb
+++ b/controls/6.02-db.rb
@@ -53,6 +53,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_checkpoints'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_checkpoints' set to 'on' " do
               subject { flag }
               its('name') { should cmp 'log_checkpoints' }
@@ -103,6 +104,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_connections'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_connections' set to 'on' " do
               subject { flag }
               its('name') { should cmp 'log_connections' }
@@ -153,6 +155,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_disconnections'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_disconnections' set to 'on' " do
               subject { flag }
               its('name') { should cmp 'log_disconnections' }
@@ -204,6 +207,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_lock_waits'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_lock_waits' set to 'on' " do
               subject { flag }
               its('name') { should cmp 'log_lock_waits' }
@@ -226,7 +230,7 @@ sub_control_id = "#{control_id}.5"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   impact 'medium'
 
-  title "[#{control_abbrev.upcase}] Ensure that the 'log_min_messages' database flag for Cloud SQL PostgreSQL instance is set appropriately"
+  title "[#{control_abbrev.upcase}] Ensure that the 'log_min_error_statement' database flag for Cloud SQL PostgreSQL instance is set appropriately"
 
   desc 'The log_min_error_statement flag defines the minimum message severity level that is considered as an error statement. Messages for error statements are logged with the SQL statement '
   desc 'rationale', 'ERROR is considered the best practice setting. Auditing helps in troubleshooting operational problems and also permits forensic analysis. If log_min_error_statement is not set to the correct value, messages may not be classified as error messages appropriately'
@@ -253,6 +257,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_min_error_statement'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_min_error_statement' set to 'ERROR' " do
               subject { flag }
               its('name') { should cmp 'log_min_error_statement' }
@@ -301,6 +306,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_temp_files'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_temp_files' set to '0' " do
               subject { flag }
               its('name') { should cmp 'log_temp_files' }
@@ -350,6 +356,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'log_min_duration_statement'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'log_min_duration_statement' set to '-1' " do
               subject { flag }
               its('name') { should cmp 'log_min_duration_statement' }

--- a/controls/6.03-db.rb
+++ b/controls/6.03-db.rb
@@ -54,6 +54,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'cross db ownership chaining'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'cross db ownership chaining' set to 'off' " do
               subject { flag }
               its('name') { should cmp 'cross db ownership chaining' }
@@ -104,6 +105,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
+            next unless flag.name == 'contained database authentication'
             describe "[#{gcp_project_id} , #{db} ] should have a database flag 'contained database authentication' set to 'off' " do
               subject { flag }
               its('name') { should cmp 'contained database authentication' }

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-17"
+version: "1.1.0-18"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
Prior to this change, each of the "db flag" related tests was looping
over all flags in a particular database and comparing both `name` and
`value` fields which results in multiple errors such as the ones below:

```
     ×  [gcp_project_id , postgres_db ] should have a database flag 'log_min_error_statement' set to 'ERROR'  name is expected to cmp == "log_min_error_statement"

     expected: "log_min_error_statement"
          got: "log_connections"

     (compared using `cmp` matcher)

     ×  [gcp_project_id , postgres_db ] should have a database flag 'log_min_error_statement' set to 'ERROR'  value is expected to cmp == "ERROR"

     expected: "ERROR"
          got: "on"
```