### PR TITLE
Skip vpc flow log checks for internal HTTPS LB subnets

### DIFF
--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -50,6 +50,7 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
   google_compute_regions(project: gcp_project_id).region_names.each do |region|
     google_compute_subnetworks(project: gcp_project_id, region: region).subnetwork_names.each do |subnet|
       subnet_obj = google_compute_subnetwork(project: gcp_project_id, region: region, name: subnet)
+      next unless subnet_obj.purpose == 'PRIVATE' # filter subnets for internal HTTPs Load Balancing
       describe "[#{gcp_project_id}] #{region}/#{subnet}" do
         subject { subnet_obj }
         if subnet_obj.methods.include?(:log_config) == true

--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -50,12 +50,17 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
   google_compute_regions(project: gcp_project_id).region_names.each do |region|
     google_compute_subnetworks(project: gcp_project_id, region: region).subnetwork_names.each do |subnet|
       subnet_obj = google_compute_subnetwork(project: gcp_project_id, region: region, name: subnet)
-      next if subnet_obj.purpose == 'INTERNAL_HTTPS_LOAD_BALANCER' # filter subnets for internal HTTPs Load Balancing
-      describe "[#{gcp_project_id}] #{region}/#{subnet}" do
-        subject { subnet_obj }
-        if subnet_obj.methods.include?(:log_config) == true
-          it 'should have logging enabled' do
-            expect(subnet_obj.log_config.enable).to be true
+      if subnet_obj.purpose == 'INTERNAL_HTTPS_LOAD_BALANCER' # filter subnets for internal HTTPs Load Balancing
+        describe "[#{gcp_project_id} #{region}/#{subnet}] cannot enable vpc flow logs. This test is Not Applicable." do
+          skip "[#{gcp_project_id} #{region}/#{subnet}] cannot enable vpc flow logs."
+        end
+      else
+        describe "[#{gcp_project_id}] #{region}/#{subnet}" do
+          subject { subnet_obj }
+          if subnet_obj.methods.include?(:log_config) == true
+            it 'should have logging enabled' do
+              expect(subnet_obj.log_config.enable).to be true
+            end
           end
         end
       end

--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -51,8 +51,8 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
     google_compute_subnetworks(project: gcp_project_id, region: region).subnetwork_names.each do |subnet|
       subnet_obj = google_compute_subnetwork(project: gcp_project_id, region: region, name: subnet)
       if subnet_obj.purpose == 'INTERNAL_HTTPS_LOAD_BALANCER' # filter subnets for internal HTTPs Load Balancing
-        describe "[#{gcp_project_id} #{region}/#{subnet}] cannot enable vpc flow logs. This test is Not Applicable." do
-          skip "[#{gcp_project_id} #{region}/#{subnet}] cannot enable vpc flow logs."
+        describe "[#{gcp_project_id} #{region}/#{subnet}] does not support VPC Flow Logs. This test is Not Applicable." do
+          skip "[#{gcp_project_id} #{region}/#{subnet}] does not support VPC Flow Logs."
         end
       else
         describe "[#{gcp_project_id}] #{region}/#{subnet}" do

--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -50,7 +50,7 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
   google_compute_regions(project: gcp_project_id).region_names.each do |region|
     google_compute_subnetworks(project: gcp_project_id, region: region).subnetwork_names.each do |subnet|
       subnet_obj = google_compute_subnetwork(project: gcp_project_id, region: region, name: subnet)
-      next unless subnet_obj.purpose == 'PRIVATE' # filter subnets for internal HTTPs Load Balancing
+      next if subnet_obj.purpose == 'INTERNAL_HTTPS_LOAD_BALANCER' # filter subnets for internal HTTPs Load Balancing
       describe "[#{gcp_project_id}] #{region}/#{subnet}" do
         subject { subnet_obj }
         if subnet_obj.methods.include?(:log_config) == true

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: Google
 copyright_email: copyright@google.com
 license: Apache-2.0
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: "1.1.0-18"
+version: "1.1.0-19"
 supports:
   - platform: gcp
 depends:


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/inspec-gcp-cis-benchmark/issues/64