### PR TITLE
Addressing conditional IAM role bindings

### DIFF
--- a/controls/1.05-iam.rb
+++ b/controls/1.05-iam.rb
@@ -43,9 +43,17 @@ This recommendation is applicable only for User-Managed user created service acc
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-service-accounts'
 
   iam_bindings_cache.iam_bindings.keys.grep(/admin/i).each do |role|
-    describe "[#{gcp_project_id}] Admin roles" do
-      subject { iam_bindings_cache.iam_bindings[role] }
-      its('members') { should_not include(/@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/) }
+    role_bindings = iam_bindings_cache.iam_bindings[role]
+    if role_bindings.members.nil?
+      impact 'none'
+      describe "[#{gcp_project_id}] Role bindings for role [#{role}] do not contain any members. This test is Not Applicable." do
+        skip "[#{gcp_project_id}] role bindings for role [#{role}] do not contain any members."
+      end
+    else
+      describe "[#{gcp_project_id}] Admin role [#{role}]" do
+        subject { role_bindings }
+        its('members') { should_not include(/@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/) }
+      end
     end
   end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: "(c) 2020, Google, Inc."
 copyright_email: "copyright@google.com"
 license: "Apache-2.0"
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: 1.1.0-19
+version: 1.1.0-20
 
 supports:
   - platform: gcp


### PR DESCRIPTION
Discovered when InSpec is checking conditional role bindings. In
case they don't have any members (it happens after the expiration of
the condition), the control simply fails because of the `nil` value.

The issue is not well surfaced. In the beginning we were getting errors
like this one:
```
...
     ✔  [gsk-gsk-direct-e7d9] Admin roles members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin roles members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ×  [gsk-gsk-direct-e7d9] Admin roles members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     expected nil not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/, but it does not respond to `include?`
     ✔  [gsk-gsk-direct-e7d9] Admin roles members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin roles members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
...
```

We then proceeded to add some debugging by adding the role as an
addition to the output:
```
...
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/ml.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/monitoring.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ×  [gsk-gsk-direct-e7d9] Admin role [roles/monitoring.admin_withcond_a3db6685e6af0a7c34cd] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     expected nil not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/, but it does not respond to `include?`
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/pubsub.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/redis.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
...
```
You can see that the error above is regarding one of the conditional
role bindings related to the `monitoring.admin` role which has no
members. In that case the `members` array is empty (or `nil`) which
does not work well with `include?`.

With the proposed fix:
```
...
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/ml.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/monitoring.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ↺  [gsk-gsk-direct-e7d9] role bindings for role [roles/monitoring.admin_withcond_a3db6685e6af0a7c34cd] do not contain any members.
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/pubsub.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
     ✔  [gsk-gsk-direct-e7d9] Admin role [roles/redis.admin] members is expected not to include /@[a-z][a-z0-9|-]{4,28}[a-z].iam.gserviceaccount.com/
...
```