### PR TITLE
Log metrix fix adding the resource types

### DIFF
--- a/controls/2.04-logging.rb
+++ b/controls/2.04-logging.rb
@@ -58,7 +58,7 @@ Granting owner role to a member (user/Service-Account) will allow members to mod
   ref 'GCP Docs', url: 'https://cloud.google.com/monitoring/alerts/'
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
 
-  log_filter = '(protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee) OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")'
+  log_filter = 'resource.type=audited_resource AND (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee) OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")'
   describe "[#{gcp_project_id}] Project Ownership changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }

--- a/controls/2.05-logging.rb
+++ b/controls/2.05-logging.rb
@@ -41,7 +41,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/audit/configure-data-access#getiampolicy-setiampolicy'
 
-  log_filter = 'protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*'
+  log_filter = 'resource.type=audited_resource AND protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*'
   describe "[#{gcp_project_id}] Audit configuration changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }

--- a/controls/2.06-logging.rb
+++ b/controls/2.06-logging.rb
@@ -41,7 +41,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-custom-roles'
 
-  log_filter = 'protoPayload.methodName="google.iam.admin.v1.CreateRole" OR protoPayload.methodName="google.iam.admin.v1.DeleteRole" OR protoPayload.methodName="google.iam.admin.v1.UpdateRole"'
+  log_filter = 'resource.type=audited_resource AND protoPayload.methodName="google.iam.admin.v1.CreateRole" OR protoPayload.methodName="google.iam.admin.v1.DeleteRole" OR protoPayload.methodName="google.iam.admin.v1.UpdateRole"'
   describe "[#{gcp_project_id}] Custom Role changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }

--- a/controls/2.07-logging.rb
+++ b/controls/2.07-logging.rb
@@ -41,7 +41,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/firewalls'
 
-  log_filter = 'jsonPayload.event_subtype="compute.firewalls.patch" OR jsonPayload.event_subtype="compute.firewalls.insert"'
+  log_filter = 'resource.type=global AND jsonPayload.event_subtype="compute.firewalls.patch" OR jsonPayload.event_subtype="compute.firewalls.insert"'
   describe "[#{gcp_project_id}] VPC FW Rule changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }

--- a/controls/2.07-logging.rb
+++ b/controls/2.07-logging.rb
@@ -49,7 +49,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
 
   google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter).metric_types.each do |metrictype|
     describe.one do
-      filter = "metric.type=\"#{metrictype}\" resource.type=\"audited_resource\""
+      filter = "metric.type=\"#{metrictype}\" resource.type=\"global\""
       google_project_alert_policies(project: gcp_project_id).where(policy_enabled_state: true).policy_names.each do |policy|
         condition = google_project_alert_policy_condition(policy: policy, filter: filter)
         describe "[#{gcp_project_id}] VPC FW Rule changes alert policy" do

--- a/controls/2.08-logging.rb
+++ b/controls/2.08-logging.rb
@@ -43,7 +43,7 @@ Monitoring changes to route tables will help ensure that all VPC traffic flows t
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/access-control/iam'
 
-  log_filter = 'jsonPayload.event_subtype="compute.routes.delete" OR jsonPayload.event_subtype="compute.routes.insert"'
+  log_filter = 'resource.type=global AND jsonPayload.event_subtype="compute.routes.delete" OR jsonPayload.event_subtype="compute.routes.insert"'
   describe "[#{gcp_project_id}] VPC Route changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }
@@ -51,7 +51,7 @@ Monitoring changes to route tables will help ensure that all VPC traffic flows t
 
   google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter).metric_types.each do |metrictype|
     describe.one do
-      filter = "metric.type=\"#{metrictype}\" resource.type=\"audited_resource\""
+      filter = "metric.type=\"#{metrictype}\" resource.type=\"global\""
       google_project_alert_policies(project: gcp_project_id).where(policy_enabled_state: true).policy_names.each do |policy|
         condition = google_project_alert_policy_condition(policy: policy, filter: filter)
         describe "[#{gcp_project_id}] VPC Route changes alert policy" do

--- a/controls/2.09-logging.rb
+++ b/controls/2.09-logging.rb
@@ -43,7 +43,7 @@ Monitoring changes to VPC will help ensure VPC traffic flow is not getting impac
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/overview'
 
-  log_filter = 'jsonPayload.event_subtype="compute.networks.insert" OR jsonPayload.event_subtype="compute.networks.patch" OR jsonPayload.event_subtype="compute.networks.delete" OR jsonPayload.event_subtype="compute.networks.removePeering" OR jsonPayload.event_subtype="compute.networks.addPeering"'
+  log_filter = 'resource.type=audited_resource AND jsonPayload.event_subtype="compute.networks.insert" OR jsonPayload.event_subtype="compute.networks.patch" OR jsonPayload.event_subtype="compute.networks.delete" OR jsonPayload.event_subtype="compute.networks.removePeering" OR jsonPayload.event_subtype="compute.networks.addPeering"'
   describe "[#{gcp_project_id}] VPC Network changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }

--- a/controls/2.10-logging.rb
+++ b/controls/2.10-logging.rb
@@ -61,3 +61,4 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
     end
   end
 end
+

--- a/controls/2.10-logging.rb
+++ b/controls/2.10-logging.rb
@@ -50,7 +50,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
 
   google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter).metric_types.each do |metrictype|
     describe.one do
-      filter = "metric.type=\"#{metrictype}\" resource.type=\"audited_resource\""
+      filter = "metric.type=\"#{metrictype}\" resource.type=\"gcs_bucket\""
       google_project_alert_policies(project: gcp_project_id).where(policy_enabled_state: true).policy_names.each do |policy|
         condition = google_project_alert_policy_condition(policy: policy, filter: filter)
         describe "[#{gcp_project_id}] Cloud Storage changes alert policy" do

--- a/controls/2.10-logging.rb
+++ b/controls/2.10-logging.rb
@@ -61,4 +61,3 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
     end
   end
 end
-

--- a/controls/2.11-logging.rb
+++ b/controls/2.11-logging.rb
@@ -49,7 +49,7 @@ Below are the few of configurable Options which may impact security posture of a
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/'
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/'
 
-  log_filter = 'protoPayload.methodName="cloudsql.instances.update"'
+  log_filter = 'resource.type=audited_resource AND protoPayload.methodName="cloudsql.instances.update"'
   describe "[#{gcp_project_id}] Cloud SQL changes filter" do
     subject { google_project_metrics(project: gcp_project_id).where(metric_filter: log_filter) }
     it { should exist }


### PR DESCRIPTION
/gcbrun

As all the log metrics does not support for the resource type as 'audited_resource' and gives the error after creating a report.
I am suggesting few changes, by providing the necessary GCP supported resources types for logging and monitoring in the code. any thoughts @KonradSchieban 
Please review @binamov 