### PR TITLE
Fix CIS Levels

### DIFF
--- a/controls/3.01-networking.rb
+++ b/controls/3.01-networking.rb
@@ -29,7 +29,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   desc 'rationale', 'The default network has automatically created firewall rules and has pre-fabricated network configuration. Based on your security and networking requirements, you should create your network and delete the default network.'
 
   tag cis_scored: true
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s

--- a/controls/5.02-storage.rb
+++ b/controls/5.02-storage.rb
@@ -44,7 +44,7 @@ bucket-level access guarantees that if a Storage bucket is not publicly accessib
 in the bucket is publicly accessible either."
 
   tag cis_scored: true
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s


### PR DESCRIPTION
Some controls have incorrectly labeled CIS Level:
- **3.01-networking**
- **5.02-storage**

This PR fixes those, based on the manual spot-check against the CIS GCP 1.1.0 reference doc. The reason our team cares about their correctness is because we prioritize our compliance implementation decisions based on whether a certain control is Level 1 (required) or Level 2 (recommended).

Thank you!
