### PR TITLE
Ensure secure boot is enabled for Shielded VMs

### DIFF
--- a/controls/4.08-vms.rb
+++ b/controls/4.08-vms.rb
@@ -26,7 +26,7 @@ gce_instances = GCECache(project: gcp_project_id, gce_zones: gce_zones).gce_inst
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
   impact 'medium'
 
-  title "[#{control_abbrev.upcase}] Ensure VM disks for critical VMs are encrypted with CustomerSupplied Encryption Keys (CSEK)"
+  title "[#{control_abbrev.upcase}] Ensure Compute instances are launched with Shielded VM enabled"
 
   desc 'To defend against against advanced threats and ensure that the boot loader and firmware
   on your VMs are signed and untampered, it is recommended that Compute instances are
@@ -68,6 +68,9 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
           expect(false).to be true
         end
       else
+        it 'should have secure boot enabled' do
+          expect(instance_object.shielded_instance_config.enable_secure_boot).to be true
+        end
         it 'should have integrity monitoring enabled' do
           expect(instance_object.shielded_instance_config.enable_integrity_monitoring).to be true
         end

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,14 +19,14 @@ copyright: "(c) 2020, Google, Inc."
 copyright_email: "copyright@google.com"
 license: "Apache-2.0"
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: 1.1.0-26
+version: 1.1.0-27
 
 supports:
   - platform: gcp
 
 depends:
   - name: inspec-gcp-helpers
-    url: https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/archive/v1.0.7.tar.gz
+    url: https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/archive/1.0.9.tar.gz
 
 inputs:
   # {{gcp_project_id}}


### PR DESCRIPTION
A brief summary of the changes:

- Adding one extra check for making sure secure boot is enabled for
Shielded VMs.
- Changing the title of the control (probably bad copy-paste).
- Updating the `inspec-gcp-helpers` dependency to the latest version.

**Note**: The versioning in `inspec-gcp-helpers` is a inconsistent. Some tags are starting with `v1...` others are starting with `1...`.