### PR TITLE
Fix/missing nist controls

### DIFF
--- a/controls/1.01-iam.rb
+++ b/controls/1.01-iam.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-3"]
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#use_corporate_login_credentials'

--- a/controls/1.01-iam.rb
+++ b/controls/1.01-iam.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#use_corporate_login_credentials'

--- a/controls/1.02-iam.rb
+++ b/controls/1.02-iam.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["IA-2"]
+  tag nist: ['IA-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/solutions/securing-gcp-account-u2f'

--- a/controls/1.03-iam.rb
+++ b/controls/1.03-iam.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["IA-2"]
+  tag nist: ['IA-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/security-key/'

--- a/controls/1.03-iam.rb
+++ b/controls/1.03-iam.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["IA-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/security-key/'

--- a/controls/1.04-iam.rb
+++ b/controls/1.04-iam.rb
@@ -45,7 +45,7 @@ Even after owners precaution, keys can be easily leaked by common development ma
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys'

--- a/controls/1.04-iam.rb
+++ b/controls/1.04-iam.rb
@@ -45,7 +45,7 @@ Even after owners precaution, keys can be easily leaked by common development ma
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys'

--- a/controls/1.05-iam.rb
+++ b/controls/1.05-iam.rb
@@ -36,7 +36,7 @@ This recommendation is applicable only for User-Managed user created service acc
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/'

--- a/controls/1.05-iam.rb
+++ b/controls/1.05-iam.rb
@@ -36,7 +36,7 @@ This recommendation is applicable only for User-Managed user created service acc
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-6"]
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/'

--- a/controls/1.06-iam.rb
+++ b/controls/1.06-iam.rb
@@ -42,7 +42,7 @@ In order to implement least privileges best practices, IAM users should not be a
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AC-3"]
+  tag nist: %w[AC-2 AC-3]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/service-accounts'

--- a/controls/1.06-iam.rb
+++ b/controls/1.06-iam.rb
@@ -42,7 +42,7 @@ In order to implement least privileges best practices, IAM users should not be a
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-6"]
+  tag nist: ["AC-2", "AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/service-accounts'

--- a/controls/1.07-iam.rb
+++ b/controls/1.07-iam.rb
@@ -40,7 +40,7 @@ GCP provides option to create one or more user-managed (also called as external 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys'

--- a/controls/1.07-iam.rb
+++ b/controls/1.07-iam.rb
@@ -40,7 +40,7 @@ GCP provides option to create one or more user-managed (also called as external 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-12"]
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys'

--- a/controls/1.08-iam.rb
+++ b/controls/1.08-iam.rb
@@ -39,7 +39,7 @@ Any user(s) should not have Service Account Admin and Service Account User, both
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AC-3"]
+  tag nist: %w[AC-2 AC-3]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/service-accounts'

--- a/controls/1.08-iam.rb
+++ b/controls/1.08-iam.rb
@@ -39,7 +39,7 @@ Any user(s) should not have Service Account Admin and Service Account User, both
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-5"]
+  tag nist: ["AC-2", "AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/iam/docs/service-accounts'

--- a/controls/1.09-iam.rb
+++ b/controls/1.09-iam.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-3"]
+  tag nist: ['AC-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation'

--- a/controls/1.09-iam.rb
+++ b/controls/1.09-iam.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-5"]
+  tag nist: ["AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation'

--- a/controls/1.10-iam.rb
+++ b/controls/1.10-iam.rb
@@ -41,7 +41,7 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation'

--- a/controls/1.10-iam.rb
+++ b/controls/1.10-iam.rb
@@ -41,7 +41,7 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-12"]
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation'

--- a/controls/1.11-iam.rb
+++ b/controls/1.11-iam.rb
@@ -38,7 +38,7 @@ Any user(s) should not have Cloud KMS Admin and any of the Cloud KMS CryptoKey E
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-5"]
+  tag nist: ["AC-2", "AC-3", "AC-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/separation-of-duties'

--- a/controls/1.11-iam.rb
+++ b/controls/1.11-iam.rb
@@ -38,7 +38,7 @@ Any user(s) should not have Cloud KMS Admin and any of the Cloud KMS CryptoKey E
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AC-3", "AC-6"]
+  tag nist: %w[AC-2 AC-3 AC-6]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/kms/docs/separation-of-duties'

--- a/controls/1.12-iam.rb
+++ b/controls/1.12-iam.rb
@@ -40,7 +40,7 @@ flow instead."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.12-iam.rb
+++ b/controls/1.12-iam.rb
@@ -40,7 +40,7 @@ flow instead."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.13-iam.rb
+++ b/controls/1.13-iam.rb
@@ -41,7 +41,7 @@ In order to reduce attack vector, API-Keys can be restricted only to the trusted
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.13-iam.rb
+++ b/controls/1.13-iam.rb
@@ -41,7 +41,7 @@ In order to reduce attack vector, API-Keys can be restricted only to the trusted
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.14-iam.rb
+++ b/controls/1.14-iam.rb
@@ -42,7 +42,7 @@ restricted to use (call) only APIs required by an application."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.14-iam.rb
+++ b/controls/1.14-iam.rb
@@ -42,7 +42,7 @@ restricted to use (call) only APIs required by an application."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/docs/authentication/api-keys'

--- a/controls/1.15-iam.rb
+++ b/controls/1.15-iam.rb
@@ -41,7 +41,7 @@ Once the key is stolen, it has no expiration, so it may be used indefinitely, un
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
 

--- a/controls/1.15-iam.rb
+++ b/controls/1.15-iam.rb
@@ -41,7 +41,7 @@ Once the key is stolen, it has no expiration, so it may be used indefinitely, un
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
 

--- a/controls/2.01-logging.rb
+++ b/controls/2.01-logging.rb
@@ -50,7 +50,7 @@ It is recommended to have effective default audit config configured in such a wa
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-6", "AU-12"]
+  tag nist: %w[AU-6 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/audit/'

--- a/controls/2.01-logging.rb
+++ b/controls/2.01-logging.rb
@@ -50,7 +50,7 @@ It is recommended to have effective default audit config configured in such a wa
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AU-2"]
+  tag nist: ["AU-6", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/audit/'

--- a/controls/2.02-logging.rb
+++ b/controls/2.02-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-4", "AU-12"]
+  tag nist: %w[AU-4 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'

--- a/controls/2.02-logging.rb
+++ b/controls/2.02-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-4", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/reference/tools/gcloud-logging'

--- a/controls/2.03-logging.rb
+++ b/controls/2.03-logging.rb
@@ -35,7 +35,7 @@ Sinks can be configured to export logs in storage buckets. It is recommended to 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/bucket-lock'

--- a/controls/2.03-logging.rb
+++ b/controls/2.03-logging.rb
@@ -35,7 +35,7 @@ Sinks can be configured to export logs in storage buckets. It is recommended to 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-6"]
+  tag nist: ['AU-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/bucket-lock'

--- a/controls/2.04-logging.rb
+++ b/controls/2.04-logging.rb
@@ -51,7 +51,7 @@ Granting owner role to a member (user/Service-Account) will allow members to mod
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.04-logging.rb
+++ b/controls/2.04-logging.rb
@@ -51,7 +51,7 @@ Granting owner role to a member (user/Service-Account) will allow members to mod
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-12"]
+  tag nist: ['AU-12']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.05-logging.rb
+++ b/controls/2.05-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.05-logging.rb
+++ b/controls/2.05-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.06-logging.rb
+++ b/controls/2.06-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.06-logging.rb
+++ b/controls/2.06-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.07-logging.rb
+++ b/controls/2.07-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.07-logging.rb
+++ b/controls/2.07-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.08-logging.rb
+++ b/controls/2.08-logging.rb
@@ -35,7 +35,7 @@ Monitoring changes to route tables will help ensure that all VPC traffic flows t
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.08-logging.rb
+++ b/controls/2.08-logging.rb
@@ -35,7 +35,7 @@ Monitoring changes to route tables will help ensure that all VPC traffic flows t
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.09-logging.rb
+++ b/controls/2.09-logging.rb
@@ -35,7 +35,7 @@ Monitoring changes to VPC will help ensure VPC traffic flow is not getting impac
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.09-logging.rb
+++ b/controls/2.09-logging.rb
@@ -35,7 +35,7 @@ Monitoring changes to VPC will help ensure VPC traffic flow is not getting impac
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.10-logging.rb
+++ b/controls/2.10-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.10-logging.rb
+++ b/controls/2.10-logging.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.11-logging.rb
+++ b/controls/2.11-logging.rb
@@ -38,7 +38,7 @@ Below are the few of configurable Options which may impact security posture of a
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3", "AU-12"]
+  tag nist: %w[AU-3 AU-12]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/2.11-logging.rb
+++ b/controls/2.11-logging.rb
@@ -38,7 +38,7 @@ Below are the few of configurable Options which may impact security posture of a
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AU-3", "AU-12"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/logging/docs/logs-based-metrics/'

--- a/controls/3.01-networking.rb
+++ b/controls/3.01-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6"]
+  tag nist: ['CM-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#firewall_rules'

--- a/controls/3.01-networking.rb
+++ b/controls/3.01-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#firewall_rules'

--- a/controls/3.02-networking.rb
+++ b/controls/3.02-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#creating_a_legacy_network'

--- a/controls/3.02-networking.rb
+++ b/controls/3.02-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6"]
+  tag nist: ['CM-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#creating_a_legacy_network'

--- a/controls/3.03-networking.rb
+++ b/controls/3.03-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6"]
+  tag nist: ['CM-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloudplatform.googleblog.com/2017/11/DNSSEC-now-available-in-Cloud-DNS.html'

--- a/controls/3.03-networking.rb
+++ b/controls/3.03-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloudplatform.googleblog.com/2017/11/DNSSEC-now-available-in-Cloud-DNS.html'

--- a/controls/3.04-networking.rb
+++ b/controls/3.04-networking.rb
@@ -35,7 +35,7 @@ When enabling DNSSEC for a managed zone, or creating a managed zone with DNSSEC,
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6"]
+  tag nist: ['CM-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/dns/dnssec-advanced#advanced_signing_options'

--- a/controls/3.04-networking.rb
+++ b/controls/3.04-networking.rb
@@ -35,7 +35,7 @@ When enabling DNSSEC for a managed zone, or creating a managed zone with DNSSEC,
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/dns/dnssec-advanced#advanced_signing_options'

--- a/controls/3.05-networking.rb
+++ b/controls/3.05-networking.rb
@@ -35,7 +35,7 @@ The algorithm used for key signing should be recommended one and it should not b
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6"]
+  tag nist: ['CM-6']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/dns/dnssec-advanced#advanced_signing_options'

--- a/controls/3.05-networking.rb
+++ b/controls/3.05-networking.rb
@@ -35,7 +35,7 @@ The algorithm used for key signing should be recommended one and it should not b
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/dns/dnssec-advanced#advanced_signing_options'

--- a/controls/3.06-networking.rb
+++ b/controls/3.06-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-7", "CA-3", "SC-7"]
+  tag nist: %w[CM-7 CA-3 SC-7]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/firewalls#blockedtraffic'

--- a/controls/3.06-networking.rb
+++ b/controls/3.06-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-7"]
+  tag nist: ["CM-7", "CA-3", "SC-7"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/firewalls#blockedtraffic'

--- a/controls/3.07-networking.rb
+++ b/controls/3.07-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-7", "CA-3", "SC-7"]
+  tag nist: %w[CM-7 CA-3 SC-7]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/firewalls#blockedtraffic'

--- a/controls/3.07-networking.rb
+++ b/controls/3.07-networking.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-7"]
+  tag nist: ["CM-7", "CA-3", "SC-7"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/firewalls#blockedtraffic'

--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -42,7 +42,7 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SI-4"]
+  tag nist: ["AU-12", "SI-4"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/using-flow-logs#enabling_vpc_flow_logging'

--- a/controls/3.08-networking.rb
+++ b/controls/3.08-networking.rb
@@ -42,7 +42,7 @@ Flow Logs provide visibility into network traffic for each VM inside the subnet 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-12", "SI-4"]
+  tag nist: %w[AU-12 SI-4]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/vpc/docs/using-flow-logs#enabling_vpc_flow_logging'

--- a/controls/3.09-networking.rb
+++ b/controls/3.09-networking.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1"]
+  tag nist: ['SC-1']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/load-balancing/docs/use-ssl-policies'

--- a/controls/3.09-networking.rb
+++ b/controls/3.09-networking.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["SC-1"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/load-balancing/docs/use-ssl-policies'

--- a/controls/4.01-vms.rb
+++ b/controls/4.01-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AC-6"]
+  tag nist: %w[AC-2 AC-6]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances'

--- a/controls/4.01-vms.rb
+++ b/controls/4.01-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-6"]
+  tag nist: ["AC-2", "AC-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances'

--- a/controls/4.02-vms.rb
+++ b/controls/4.02-vms.rb
@@ -42,7 +42,7 @@ When an instance is configured with Compute Engine default service account with 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2", "AC-6"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances'

--- a/controls/4.02-vms.rb
+++ b/controls/4.02-vms.rb
@@ -42,7 +42,7 @@ When an instance is configured with Compute Engine default service account with 
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "AC-6"]
+  tag nist: %w[AC-2 AC-6]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances'

--- a/controls/4.03-vms.rb
+++ b/controls/4.03-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys'

--- a/controls/4.03-vms.rb
+++ b/controls/4.03-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys'

--- a/controls/4.04-vms.rb
+++ b/controls/4.04-vms.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ['AC-2']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/managing-instance-access'

--- a/controls/4.04-vms.rb
+++ b/controls/4.04-vms.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["AC-2"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/managing-instance-access'

--- a/controls/4.05-vms.rb
+++ b/controls/4.05-vms.rb
@@ -42,7 +42,7 @@ Therefore interactive serial console support should be disabled."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-7"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/interacting-with-serial-console'

--- a/controls/4.05-vms.rb
+++ b/controls/4.05-vms.rb
@@ -42,7 +42,7 @@ Therefore interactive serial console support should be disabled."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-7"]
+  tag nist: ['CM-7']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/interacting-with-serial-console'

--- a/controls/4.06-vms.rb
+++ b/controls/4.06-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["CM-6", "CM-8"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#canipforward'

--- a/controls/4.06-vms.rb
+++ b/controls/4.06-vms.rb
@@ -36,7 +36,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CM-6", "CM-8"]
+  tag nist: %w[CM-6 CM-8]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/networking#canipforward'

--- a/controls/4.07-vms.rb
+++ b/controls/4.07-vms.rb
@@ -42,7 +42,7 @@ At least business critical VMs should have VM disks encrypted with CSEK."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1"]
+  tag nist: ['SC-1']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#encrypt_a_new_persistent_disk_with_your_own_keys'

--- a/controls/4.07-vms.rb
+++ b/controls/4.07-vms.rb
@@ -42,7 +42,7 @@ At least business critical VMs should have VM disks encrypted with CSEK."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["SC-1"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#encrypt_a_new_persistent_disk_with_your_own_keys'

--- a/controls/4.08-vms.rb
+++ b/controls/4.08-vms.rb
@@ -54,7 +54,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1"]
+  tag nist: ['SC-1']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/modifying-shielded-vm'

--- a/controls/4.08-vms.rb
+++ b/controls/4.08-vms.rb
@@ -54,7 +54,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["SC-1"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/compute/docs/instances/modifying-shielded-vm'

--- a/controls/5.01-storage.rb
+++ b/controls/5.01-storage.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ["AC-2", "CA-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/access-control/iam-reference'

--- a/controls/5.01-storage.rb
+++ b/controls/5.01-storage.rb
@@ -33,7 +33,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2", "CA-3"]
+  tag nist: %w[AC-2 CA-3]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/access-control/iam-reference'

--- a/controls/5.02-storage.rb
+++ b/controls/5.02-storage.rb
@@ -48,7 +48,7 @@ in the bucket is publicly accessible either."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: [AC-3]
+  tag nist: ['AC-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/uniform-bucket-level-access'

--- a/controls/5.02-storage.rb
+++ b/controls/5.02-storage.rb
@@ -48,7 +48,7 @@ in the bucket is publicly accessible either."
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: [AC-3]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/uniform-bucket-level-access'

--- a/controls/6.01-db.rb
+++ b/controls/6.01-db.rb
@@ -40,7 +40,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["IA-5"]
+  tag nist: ['IA-5']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/create-manage-users'
@@ -68,7 +68,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1"]
+  tag nist: ['SC-1']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/flags'

--- a/controls/6.01-db.rb
+++ b/controls/6.01-db.rb
@@ -40,7 +40,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-7"]
+  tag nist: ["IA-5"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/create-manage-users'
@@ -68,6 +68,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["SC-1"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/flags'

--- a/controls/6.02-db.rb
+++ b/controls/6.02-db.rb
@@ -37,7 +37,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -88,7 +88,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -140,7 +140,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -193,7 +193,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -244,7 +244,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -294,7 +294,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -345,7 +345,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AU-3"]
+  tag nist: ['AU-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'

--- a/controls/6.02-db.rb
+++ b/controls/6.02-db.rb
@@ -37,7 +37,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CA-3", "SC-7"]
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -88,6 +88,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -139,6 +140,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -191,6 +193,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -241,6 +244,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -290,6 +294,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'
@@ -340,6 +345,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AU-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/flags#setting_a_database_flag'

--- a/controls/6.03-db.rb
+++ b/controls/6.03-db.rb
@@ -88,6 +88,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
+  tag nist: ["AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/sqlserver/flags'

--- a/controls/6.03-db.rb
+++ b/controls/6.03-db.rb
@@ -37,7 +37,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-3"]
+  tag nist: ['AC-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/sqlserver/flags'
@@ -88,7 +88,7 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   tag cis_gcp: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-3"]
+  tag nist: ['AC-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/sqlserver/flags'

--- a/controls/6.04-db.rb
+++ b/controls/6.04-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-7"]
+  tag nist: ["SC-1", "SC-8"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/configure-ssl-instance'

--- a/controls/6.04-db.rb
+++ b/controls/6.04-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1", "SC-8"]
+  tag nist: %w[SC-1 SC-8]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/postgres/configure-ssl-instance'

--- a/controls/6.05-db.rb
+++ b/controls/6.05-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1", "AC-3"]
+  tag nist: %w[SC-1 AC-3]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/configure-ip'

--- a/controls/6.05-db.rb
+++ b/controls/6.05-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: []
+  tag nist: ["SC-1", "AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/configure-ip'

--- a/controls/6.06-db.rb
+++ b/controls/6.06-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["SC-1"]
+  tag nist: ['SC-1']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/configure-private-ip'

--- a/controls/6.06-db.rb
+++ b/controls/6.06-db.rb
@@ -35,7 +35,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CA-3", "SC-7"]
+  tag nist: ["SC-1"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/configure-private-ip'

--- a/controls/6.07-db.rb
+++ b/controls/6.07-db.rb
@@ -37,7 +37,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["CP-9"]
+  tag nist: ['CP-9']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/sql/docs/mysql/backup-recovery/backups'

--- a/controls/7.01-bq.rb
+++ b/controls/7.01-bq.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-3"]
+  tag nist: ['AC-3']
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/access-control/iam-reference'

--- a/controls/7.01-bq.rb
+++ b/controls/7.01-bq.rb
@@ -34,7 +34,7 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   tag cis_gcp: control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
-  tag nist: ["AC-2"]
+  tag nist: ["AC-3"]
 
   ref 'CIS Benchmark', url: cis_url.to_s
   ref 'GCP Docs', url: 'https://cloud.google.com/storage/docs/access-control/iam-reference'

--- a/inspec.yml
+++ b/inspec.yml
@@ -19,7 +19,7 @@ copyright: "(c) 2020, Google, Inc."
 copyright_email: "copyright@google.com"
 license: "Apache-2.0"
 summary: "Inspec Google Cloud Platform Center for Internet Security Benchmark v1.1 Profile"
-version: 1.1.0-27
+version: 1.1.0-28
 
 supports:
   - platform: gcp


### PR DESCRIPTION
- Add missing NIST 800-53 tags
- Correct NIST 800-53 tags based on https://github.com/mitre/inspec_tools/blob/master/lib/data/NIST_Map_09212017B_CSC-CIS_Critical_Security_Controls_VER_6.1_Excel_9.1.2016.xlsx
- Rubocop

@aaronlippold @binamov fyi