### PR TITLE
Avoid marking applicable controls as Not Applicable

### DIFF
--- a/controls/1.04-iam.rb
+++ b/controls/1.04-iam.rb
@@ -23,7 +23,7 @@ control_abbrev = 'iam'
 service_account_cache = ServiceAccountCache(project: gcp_project_id)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that there are only GCP-managed service account keys for each service account"
 
@@ -58,7 +58,6 @@ Even after owners precaution, keys can be easily leaked by common development ma
         its('key_types') { should_not include 'USER_MANAGED' }
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] ServiceAccount [#{sa_email}] does not have user-managed keys. This test is Not Applicable." do
         skip "[#{gcp_project_id}] ServiceAccount [#{sa_email}] does not have user-managed keys."
       end

--- a/controls/1.07-iam.rb
+++ b/controls/1.07-iam.rb
@@ -24,7 +24,7 @@ sa_key_older_than_seconds = input('sa_key_older_than_seconds')
 service_account_cache = ServiceAccountCache(project: gcp_project_id)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure user-managed/external keys for service accounts are rotated every 90 days or less"
 
@@ -55,7 +55,6 @@ GCP provides option to create one or more user-managed (also called as external 
         it { should_not exist }
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] ServiceAccount [#{sa_email}] does not have user-managed keys. This test is Not Applicable." do
         skip "[#{gcp_project_id}] ServiceAccount [#{sa_email}] does not have user-managed keys."
       end

--- a/controls/1.08-iam.rb
+++ b/controls/1.08-iam.rb
@@ -23,7 +23,7 @@ control_abbrev = 'iam'
 iam_bindings_cache = IAMBindingsCache(project: gcp_project_id)
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that Separation of duties is enforced while assigning service account related roles to users"
 
@@ -48,16 +48,15 @@ Any user(s) should not have Service Account Admin and Service Account User, both
 
   sa_admins = iam_bindings_cache.iam_bindings['roles/iam.serviceAccountAdmin']
   if sa_admins.nil? || sa_admins.members.count.zero?
-    impact 'none'
     describe "[#{gcp_project_id}] does not contain users with roles/serviceAccountAdmin. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not contain users with roles/serviceAccountAdmin"
     end
   elsif iam_bindings_cache.iam_bindings['roles/iam.serviceAccountUser'].nil?
-    impact 'none'
     describe "[#{gcp_project_id}] does not contain users with roles/serviceAccountUser. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not contain users with roles/serviceAccountUser"
     end
   else
+    impact 'medium'
     describe "[#{gcp_project_id}] roles/serviceAccountUser" do
       subject { iam_bindings_cache.iam_bindings['roles/iam.serviceAccountUser'] }
       sa_admins.members.each do |sa_admin|

--- a/controls/1.09-iam.rb
+++ b/controls/1.09-iam.rb
@@ -21,7 +21,7 @@ control_id = '1.9'
 control_abbrev = 'iam'
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that Cloud KMS cryptokeys are not anonymously or publicly accessible"
 
@@ -47,21 +47,18 @@ control "cis-gcp-#{control_id}-#{control_abbrev}" do
   # Ensure that keys aren't publicly accessible
   locations.each do |location|
     if kms_cache.kms_key_ring_names[location].empty?
-      impact 'none'
       describe "[#{gcp_project_id}] does not contain any key rings in [#{location}]. This test is Not Applicable." do
         skip "[#{gcp_project_id}] does not contain any key rings in [#{location}]"
       end
     else
       kms_cache.kms_key_ring_names[location].each do |keyring|
         if kms_cache.kms_crypto_keys[location][keyring].empty?
-          impact 'none'
           describe "[#{gcp_project_id}] key ring [#{keyring}] does not contain any cryptographic keys. This test is Not Applicable." do
             skip "[#{gcp_project_id}] key ring [#{keyring}] does not contain any cryptographic keys"
           end
         else
           kms_cache.kms_crypto_keys[location][keyring].each do |keyname|
             if google_kms_crypto_key_iam_policy(project: gcp_project_id, location: location, key_ring_name: keyring, crypto_key_name: keyname).bindings.nil?
-              impact 'none'
               describe "[#{gcp_project_id}] key ring [#{keyring}] key [#{keyname}] does not have any IAM bindings. This test is Not Applicable." do
                 skip "[#{gcp_project_id}] key ring [#{keyring}] key [#{keyname}] does not have any IAM bindings"
               end

--- a/controls/1.10-iam.rb
+++ b/controls/1.10-iam.rb
@@ -22,7 +22,7 @@ control_abbrev = 'iam'
 kms_rotation_period_seconds = input('kms_rotation_period_seconds')
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure Encryption keys are rotated within a period of 90 days"
 
@@ -56,14 +56,12 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
   # Ensure KMS keys autorotate 90d or less
   locations.each do |location|
     if kms_cache.kms_key_ring_names[location].empty?
-      impact 'none'
       describe "[#{gcp_project_id}] does not contain any key rings in [#{location}]. This test is Not Applicable." do
         skip "[#{gcp_project_id}] does not contain any key rings in [#{location}]"
       end
     else
       kms_cache.kms_key_ring_names[location].each do |keyring|
         if kms_cache.kms_crypto_keys[location][keyring].empty?
-          impact 'none'
           describe "[#{gcp_project_id}] key ring [#{keyring}] does not contain any cryptographic keys. This test is Not Applicable." do
             skip "[#{gcp_project_id}] key ring [#{keyring}] does not contain any cryptographic keys"
           end
@@ -71,6 +69,7 @@ A key is used to protect some corpus of data. You could encrypt a collection of 
           kms_cache.kms_crypto_keys[location][keyring].each do |keyname|
             key = google_kms_crypto_key(project: gcp_project_id, location: location, key_ring_name: keyring, name: keyname)
             next unless key.purpose == 'ENCRYPT_DECRYPT' && key.primary_state == 'ENABLED'
+            impact 'medium'
             describe "[#{gcp_project_id}] #{key.crypto_key_name}" do
               subject { key }
               its('rotation_period') { should_not eq nil }

--- a/controls/3.04-networking.rb
+++ b/controls/3.04-networking.rb
@@ -21,7 +21,7 @@ control_id = '3.4'
 control_abbrev = 'networking'
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that RSASHA1 is not used for key-signing key in Cloud DNS DNSSEC"
 
@@ -43,7 +43,6 @@ When enabling DNSSEC for a managed zone, or creating a managed zone with DNSSEC,
   managed_zone_names = google_dns_managed_zones(project: gcp_project_id).zone_names
 
   if managed_zone_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have DNS Zones. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have DNS Zones."
     end
@@ -51,12 +50,12 @@ When enabling DNSSEC for a managed zone, or creating a managed zone with DNSSEC,
     managed_zone_names.each do |dnszone|
       zone = google_dns_managed_zone(project: gcp_project_id, zone: dnszone)
       if zone.visibility == 'private'
-        impact 'none'
         describe "[#{gcp_project_id}] DNS zone #{dnszone} has private visibility. This test is not applicable for private zones." do
           skip "[#{gcp_project_id}] DNS zone #{dnszone} has private visibility."
         end
       elsif zone.dnssec_config.state == 'on'
         zone.dnssec_config.default_key_specs.select { |spec| spec.key_type == 'keySigning' }.each do |spec|
+          impact 'medium'
           describe "[#{gcp_project_id}] DNS Zone [#{dnszone}] with DNSSEC key-signing" do
             subject { spec }
             its('algorithm') { should_not cmp 'RSASHA1' }
@@ -64,6 +63,7 @@ When enabling DNSSEC for a managed zone, or creating a managed zone with DNSSEC,
           end
         end
       else
+        impact 'medium'
         describe "[#{gcp_project_id}] DNS Zone [#{dnszone}] DNSSEC" do
           subject { 'off' }
           it { should cmp 'on' }

--- a/controls/3.05-networking.rb
+++ b/controls/3.05-networking.rb
@@ -21,7 +21,7 @@ control_id = '3.5'
 control_abbrev = 'networking'
 
 control "cis-gcp-#{control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that RSASHA1 is not used for zone-signing key in Cloud DNS DNSSEC"
 
@@ -43,7 +43,6 @@ The algorithm used for key signing should be recommended one and it should not b
   managed_zone_names = google_dns_managed_zones(project: gcp_project_id).zone_names
 
   if managed_zone_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have DNS Zones. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have DNS Zones."
     end
@@ -51,12 +50,12 @@ The algorithm used for key signing should be recommended one and it should not b
     managed_zone_names.each do |dnszone|
       zone = google_dns_managed_zone(project: gcp_project_id, zone: dnszone)
       if zone.visibility == 'private'
-        impact 'none'
         describe "[#{gcp_project_id}] DNS zone #{dnszone} has private visibility. This test is not applicable for private zones." do
           skip "[#{gcp_project_id}] DNS zone #{dnszone} has private visibility."
         end
       elsif zone.dnssec_config.state == 'on'
         zone.dnssec_config.default_key_specs.select { |spec| spec.key_type == 'zoneSigning' }.each do |spec|
+          impact 'medium'
           describe "[#{gcp_project_id}] DNS Zone [#{dnszone}] with DNSSEC zone-signing" do
             subject { spec }
             its('algorithm') { should_not cmp 'RSASHA1' }
@@ -64,6 +63,7 @@ The algorithm used for key signing should be recommended one and it should not b
           end
         end
       else
+        impact 'medium'
         describe "[#{gcp_project_id}] DNS Zone [#{dnszone}] DNSSEC" do
           subject { 'off' }
           it { should cmp 'on' }

--- a/controls/6.01-db.rb
+++ b/controls/6.01-db.rb
@@ -138,8 +138,8 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'MYSQL'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
@@ -148,7 +148,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'local_infile'
-            impact 'medium'
             describe flag do
               its('name') { should cmp 'local_infile' }
               its('value') { should cmp 'off' }

--- a/controls/6.01-db.rb
+++ b/controls/6.01-db.rb
@@ -55,7 +55,7 @@ end
 # 6.1.2
 sub_control_id = "#{control_id}.2"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'skip_show_database' database flag for Cloud SQL Mysql
   instance is set to 'on'"
@@ -83,13 +83,13 @@ applicable to Mysql database instances."
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'MYSQL'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'skip_show_database'
@@ -101,7 +101,6 @@ applicable to Mysql database instances."
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a MySQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a MySQL database"
       end
@@ -109,7 +108,6 @@ applicable to Mysql database instances."
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -119,7 +117,7 @@ end
 # 6.1.3
 sub_control_id = "#{control_id}.3"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'local_infile' database flag for a Cloud SQL Mysql instance is set to 'off'"
 
@@ -141,15 +139,16 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'MYSQL'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
+        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'local_infile'
+            impact 'medium'
             describe flag do
               its('name') { should cmp 'local_infile' }
               its('value') { should cmp 'off' }
@@ -158,7 +157,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a MySQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a MySQL database"
       end
@@ -166,7 +164,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end

--- a/controls/6.02-db.rb
+++ b/controls/6.02-db.rb
@@ -30,7 +30,7 @@ sql_instance_names = sql_cache.instance_names
 # 6.2.1
 sub_control_id = "#{control_id}.1"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_checkpoints' database flag for Cloud SQL PostgreSQL instance is set to 'on'"
 
@@ -49,14 +49,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_checkpoints'
@@ -69,7 +68,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -77,7 +75,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -87,7 +84,7 @@ end
 # 6.2.2
 sub_control_id = "#{control_id}.2"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_error_verbosity' database flag for Cloud SQL
   PostgreSQL instance is set to 'DEFAULT' or stricter"
@@ -119,14 +116,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_error_verbosity'
@@ -139,7 +135,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -147,7 +142,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -157,7 +151,7 @@ end
 # 6.2.3
 sub_control_id = "#{control_id}.3"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_connections' database flag for Cloud SQL PostgreSQL instance is set to 'on'"
 
@@ -178,14 +172,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_connections'
@@ -198,7 +191,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -206,7 +198,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -216,7 +207,7 @@ end
 # 6.2.4
 sub_control_id = "#{control_id}.4"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_disconnections' database flag for Cloud SQL PostgreSQL instance is set to 'on'"
 
@@ -237,14 +228,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_disconnections'
@@ -257,7 +247,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -265,7 +254,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -275,7 +263,7 @@ end
 # 6.2.5
 sub_control_id = "#{control_id}.5"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_duration' database flag for Cloud SQL PostgreSQL instance is set to 'on' "
 
@@ -301,14 +289,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_duration'
@@ -321,7 +308,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -329,7 +315,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -339,7 +324,7 @@ end
 # 6.2.6
 sub_control_id = "#{control_id}.6"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_lock_waits' database flag for Cloud SQL PostgreSQL instance is set to 'on'"
 
@@ -361,14 +346,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_lock_waits'
@@ -381,7 +365,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -389,7 +372,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -399,7 +381,7 @@ end
 # 6.2.7
 sub_control_id = "#{control_id}.7"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_statement' database flag for Cloud SQL PostgreSQL instance is set appropriately"
 
@@ -436,14 +418,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_statement'
@@ -456,7 +437,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -464,7 +444,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -474,7 +453,7 @@ end
 # 6.2.8
 sub_control_id = "#{control_id}.8"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_hostname' database flag for Cloud SQL PostgreSQL instance is set appropriately"
 
@@ -502,14 +481,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_hostname'
@@ -522,7 +500,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -530,7 +507,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -540,7 +516,7 @@ end
 # 6.2.9
 sub_control_id = "#{control_id}.9"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_parser_stats' database flag for Cloud SQL PostgreSQL
   instance is set to 'off'"
@@ -567,14 +543,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_parser_stats'
@@ -587,7 +562,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -595,7 +569,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -605,7 +578,7 @@ end
 # 6.2.10
 sub_control_id = "#{control_id}.10"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_planner_stats' database flag for Cloud SQL
   PostgreSQL instance is set to 'off'"
@@ -632,14 +605,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_planner_stats'
@@ -652,7 +624,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -660,7 +631,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -697,14 +667,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_executor_stats'
@@ -717,7 +686,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -735,7 +703,7 @@ end
 # 6.2.12
 sub_control_id = "#{control_id}.12"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_statement_stats' database flag for Cloud SQL
   PostgreSQL instance is set to 'off'"
@@ -760,14 +728,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_statement_stats'
@@ -780,7 +747,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -788,7 +754,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -798,7 +763,7 @@ end
 # 6.2.13
 sub_control_id = "#{control_id}.13"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_min_messages' database flag for Cloud SQL
   PostgreSQL instance is set appropriately"
@@ -830,14 +795,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_min_messages'
@@ -850,7 +814,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -858,7 +821,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -868,7 +830,7 @@ end
 # 6.2.14
 sub_control_id = "#{control_id}.14"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'log_min_error_statement' database flag for Cloud SQL
   PostgreSQL instance is set to 'Error' or stricter"
@@ -898,14 +860,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_min_error_statement'
@@ -918,7 +879,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -936,7 +896,7 @@ end
 # 6.2.15
 sub_control_id = "#{control_id}.15"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_temp_files' database flag for Cloud SQL
   PostgreSQL instance is set to '0' (on)"
@@ -963,14 +923,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_temp_files'
@@ -983,7 +942,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -991,7 +949,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end
@@ -1001,7 +958,7 @@ end
 # 6.2.16
 sub_control_id = "#{control_id}.16"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'log_min_duration_statement' database flag for
   Cloud SQL PostgreSQL instance is set to '-1' (disabled)"
@@ -1024,14 +981,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'POSTGRES'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'log_min_duration_statement'
@@ -1044,7 +1000,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a PostgreSQL database"
       end
@@ -1052,7 +1007,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end

--- a/controls/6.03-db.rb
+++ b/controls/6.03-db.rb
@@ -26,7 +26,7 @@ sql_instance_names = sql_cache.instance_names
 # 6.3.1
 sub_control_id = "#{control_id}.1"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'external scripts enabled' database flag for Cloud SQL SQL Server instance is set to 'off'"
 
@@ -52,14 +52,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'external scripts enabled'
@@ -72,7 +71,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -80,7 +78,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -90,7 +87,7 @@ end
 # 6.3.2
 sub_control_id = "#{control_id}.2"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'cross db ownership chaining' database flag for Cloud SQL Server instance is set to 'off'"
 
@@ -110,14 +107,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'cross db ownership chaining'
@@ -130,7 +126,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -148,7 +143,7 @@ end
 # 6.3.3
 sub_control_id = "#{control_id}.3"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'user connections' database flag for Cloud SQL SQL Server instance is set as appropriate"
 
@@ -179,14 +174,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'user connections'
@@ -199,7 +193,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -207,7 +200,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -217,7 +209,7 @@ end
 # 6.3.4
 sub_control_id = "#{control_id}.4"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'user options' database flag for Cloud SQL SQL Server instance is not configured"
 
@@ -246,14 +238,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'user options'
@@ -265,7 +256,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -273,7 +263,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -283,7 +272,7 @@ end
 # 6.3.5
 sub_control_id = "#{control_id}.5"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure 'remote access' database flag for Cloud SQL SQL Server instance is set to 'off'"
 
@@ -313,14 +302,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'remote access'
@@ -333,7 +321,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -341,7 +328,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -351,7 +337,7 @@ end
 # 6.3.6
 sub_control_id = "#{control_id}.6"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure '3625 (trace flag)' database flag for Cloud SQL SQL Server instance is set to 'off'"
 
@@ -379,14 +365,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == '3625'
@@ -407,7 +392,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe 'There are no Cloud SQL Instances in this project. This test is Not Applicable.' do
       skip 'There are no Cloud SQL Instances in this project'
     end
@@ -417,7 +401,7 @@ end
 # 6.3.7
 sub_control_id = "#{control_id}.7"
 control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
-  impact 'medium'
+  impact 'none'
 
   title "[#{control_abbrev.upcase}] Ensure that the 'contained database authentication' database flag for Cloud SQL server instance is set to 'off'"
 
@@ -438,14 +422,13 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
 
   sql_instance_names.each do |db|
     if sql_cache.instance_objects[db].database_version.include? 'SQLSERVER'
+      impact 'medium'
       if sql_cache.instance_objects[db].settings.database_flags.nil?
-        impact 'medium'
         describe "[#{gcp_project_id} , #{db} ] does not any have database flags." do
           subject { false }
           it { should be true }
         end
       else
-        impact 'medium'
         describe.one do
           sql_cache.instance_objects[db].settings.database_flags.each do |flag|
             next unless flag.name == 'contained database authentication'
@@ -458,7 +441,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
         end
       end
     else
-      impact 'none'
       describe "[#{gcp_project_id}] [#{db}] is not a SQL Server database. This test is Not Applicable." do
         skip "[#{gcp_project_id}] [#{db}] is not a SQL Server database"
       end
@@ -466,7 +448,6 @@ control "cis-gcp-#{sub_control_id}-#{control_abbrev}" do
   end
 
   if sql_instance_names.empty?
-    impact 'none'
     describe "[#{gcp_project_id}] does not have CloudSQL instances. This test is Not Applicable." do
       skip "[#{gcp_project_id}] does not have CloudSQL instances."
     end


### PR DESCRIPTION
This fixes #96.

Currently there is an issue where tests that are applicable will get marked as NA due to the impact being set to 'none' inside of a loop, which overrides the existing impact. This restructures those tests to properly handle such situations, causing correct results to be displayed.

Note: This currently has a dependency on #94, I can rebase it once the other PR is merged.