### PR TITLE
fix 6.2.8 input var ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ attrs.yml
 Gemfile.lock
 inputs.yml
 vendor
+.DS_Store

--- a/controls/6.02-db.rb
+++ b/controls/6.02-db.rb
@@ -21,6 +21,7 @@ log_min_messages = input('log_min_messages')
 log_min_error_statement = input('log_min_error_statement')
 log_error_verbosity = input('log_error_verbosity')
 log_statement = input('log_statement')
+log_hostname = input('log_hostname')
 control_id = '6.2'
 control_abbrev = 'db'
 


### PR DESCRIPTION
The input variable for check 6..2.8 is not being imported to the module resulting in chef/inspec crashing when evaluating this check; simply adding a line to  import it.